### PR TITLE
Fix unused parameter warnings:

### DIFF
--- a/math_group.c
+++ b/math_group.c
@@ -259,7 +259,7 @@ static int modp_setraw(struct group *grp, gcry_mpi_t d, unsigned char *s, int l)
 {
 	int i;
 
-	grp = NULL; /* unused */
+	(void)grp; /* unused parameter */
 
 	gcry_mpi_set_ui(d, 0);
 	for (i = 0; i < l; i++) {

--- a/sysdep.c
+++ b/sysdep.c
@@ -510,13 +510,13 @@ int tun_close(int fd, char *dev)
 #elif defined(__CYGWIN__)
 int tun_close(int fd, char *dev)
 {
-	dev = NULL; /* unused */
+	(void)dev; /* unused parameter */
 	return CloseHandle((HANDLE) get_osfhandle(fd));
 }
 #else
 int tun_close(int fd, char *dev)
 {
-	dev = NULL; /*unused */
+	(void)dev; /* unused parameter */
 	return close(fd);
 }
 #endif
@@ -658,7 +658,7 @@ int tun_get_hwaddr(int fd, char *dev, uint8_t *hwaddr)
 #if defined(__CYGWIN__)
 	ULONG len;
 
-	dev = NULL; /* unused */
+	(void)dev; /* unused parameter */
 	if (!DeviceIoControl((HANDLE) get_osfhandle(fd), TAP_IOCTL_GET_MAC,
 		hwaddr, ETH_ALEN, hwaddr, ETH_ALEN, &len, NULL)) {
 		printf("Cannot get HW address\n");
@@ -686,9 +686,9 @@ int tun_get_hwaddr(int fd, char *dev, uint8_t *hwaddr)
 	return 0;
 #else
 	/* todo: implement using SIOCGLIFADDR */
-	fd = 0;
-	dev = 0;
-	hwaddr = 0;
+	(void)fd; /* unused parameter */
+	(void)dev; /* unused parameter */
+	(void)hwaddr; /* unused parameter */
 	errno = ENOSYS;
 	return -1;
 #endif

--- a/tunip.c
+++ b/tunip.c
@@ -879,7 +879,7 @@ static void vpnc_main_loop(struct sa_block *s)
 				}
 			}
 			DEBUG(2,printf("lifetime status: %ld of %u seconds used, %u|%u of %u kbytes used\n",
-				time(NULL) - s->ipsec.life.start,
+				(long)(time(NULL) - s->ipsec.life.start),
 				s->ipsec.life.seconds,
 				s->ipsec.life.rx/1024,
 				s->ipsec.life.tx/1024,


### PR DESCRIPTION
  - (void)grp in math_group.c:262
  - (void)dev, (void)fd, (void)hwaddr in sysdep.c

* (long)(time(NULL) - s->ipsec.life.start) in tunip.c:882 cast to fix time_t format warning