### PR TITLE
Pruning unused, insecure algorithms

### DIFF
--- a/supp.c
+++ b/supp.c
@@ -28,8 +28,6 @@
 #include <stdlib.h>
 
 const supported_algo_t supp_dh_group[] = {
-	{"nopfs", 0, 0, 0, 0},
-	{"dh1", OAKLEY_GRP_1, IKE_GROUP_MODP_768,  IKE_GROUP_MODP_768,  0},
 	{"dh2", OAKLEY_GRP_2, IKE_GROUP_MODP_1024, IKE_GROUP_MODP_1024, 0},
 	{"dh5", OAKLEY_GRP_5, IKE_GROUP_MODP_1536, IKE_GROUP_MODP_1536, 0},
 	/*{ "dh7", OAKLEY_GRP_7, IKE_GROUP_EC2N_163K, IKE_GROUP_EC2N_163K, 0 } note: code missing */
@@ -37,14 +35,11 @@ const supported_algo_t supp_dh_group[] = {
 };
 
 const supported_algo_t supp_hash[] = {
-	{"md5", GCRY_MD_MD5, IKE_HASH_MD5, IPSEC_AUTH_HMAC_MD5, 0},
 	{"sha1", GCRY_MD_SHA1, IKE_HASH_SHA, IPSEC_AUTH_HMAC_SHA, 0},
 	{NULL, 0, 0, 0, 0}
 };
 
 const supported_algo_t supp_crypt[] = {
-	{"null", GCRY_CIPHER_NONE, IKE_ENC_NO_CBC, ISAKMP_IPSEC_ESP_NULL, 0},
-	{"des", GCRY_CIPHER_DES, IKE_ENC_DES_CBC, ISAKMP_IPSEC_ESP_DES, 0},
 	{"3des", GCRY_CIPHER_3DES, IKE_ENC_3DES_CBC, ISAKMP_IPSEC_ESP_3DES, 0},
 	{"aes128", GCRY_CIPHER_AES128, IKE_ENC_AES_CBC, ISAKMP_IPSEC_ESP_AES, 128},
 	{"aes192", GCRY_CIPHER_AES192, IKE_ENC_AES_CBC, ISAKMP_IPSEC_ESP_AES, 192},


### PR DESCRIPTION
* Remove DES encryption (completely broken since 1999)
* Remove NULL encryption (no security)
* Remove MD5 hashing (collision attacks since 2004)
* Remove DH Group 1 (768-bit MODP, factored in 2015)
* Remove nopfs option (no Perfect Forward Secrecy)

Resulting build is still functional with the Cisco ASA I need to use.